### PR TITLE
Update frontend docs and remove Lovable

### DIFF
--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -1,6 +1,7 @@
 # Frontend Integration Guide
 
 This document explains how to connect the React frontend at **feelfwd.app** to the Feel Forward backend deployed on AWS.
+This project relies on an AI automation agent to build and deploy the frontend. A human collaborator manages the domain and DNS configuration. Follow the steps below to keep the environment in sync.
 
 ## Overview
 
@@ -32,12 +33,9 @@ VITE_API_URL=https://api.feelfwd.app
 ```
 
 Use `import.meta.env.VITE_API_URL` when making API calls from the frontend.
+## Automation
 
-## Lovable Automation Agent
-
-"Lovable" is the name of the automation agent responsible for provisioning and maintaining the front‑end stack. It runs the CDK deployment and uploads the latest build to CloudFront.
-
-The frontend application itself does **not** introduce Lovable as a user‑facing character. Instead, Lovable is an internal helper that ensures infrastructure and deployment remain automated.
+The AI agent runs the CDK deployment and uploads the latest build to the hosting bucket. The human maintains DNS records and verifies that the domain points to the CloudFront distribution.
 
 ## Build & Deploy
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ Set the environment variable `OPENAI_API_KEY` to enable LLM features. The code i
 
 The `infra/` directory contains an AWS CDK app that provisions Route 53 records and static hosting for the frontend. Run `cdk deploy` as described in `infra/README.md` to bootstrap DNS and hosting automatically.
 
-**Lovable** runs the frontend deployments to keep the frontend stack up to date.
+An AI agent handles frontend deployments, while a human collaborator manages DNS and domain records.
 
 Set the environment variable `OPENAI_API_KEY` to enable LLM features. The code is ready to be containerized and deployed on AWS using your preferred approach (e.g., ECS, Lambda, or EC2). See DEPLOY.md for step-by-step AWS deployment instructions.


### PR DESCRIPTION
## Summary
- clarify that an AI agent manages the front‑end with help from a human
- remove all references to "Lovable" in documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848067c378c832a9f161e7a3896960d