### PR TITLE
Add health endpoint and integration tests

### DIFF
--- a/api.py
+++ b/api.py
@@ -32,6 +32,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Health check endpoint for load balancer
+@app.get("/health")
+async def health() -> dict:
+    """Return service status for health checks."""
+    return {"status": "ok"}
+
 # ---- Rate limiting ---------------------------------------------------------
 REQUEST_LOG = defaultdict(list)
 RATE = 60

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,11 @@ from api import app
 
 client = TestClient(app)
 
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
 def test_phase0_factors():
     resp = client.post("/phase0/factors", json={"topic": "choosing a new job"})
     assert resp.status_code == 200
@@ -14,6 +19,17 @@ def test_phase0_factors():
     assert "factors" in data
     assert isinstance(data["factors"], list)
 
+
+def test_phase1_preferences():
+    pref = {
+        "factor": "salary",
+        "importance": 5,
+        "hasLimit": False,
+    }
+    resp = client.post("/phase1/preferences", json={"preferences": [pref]})
+    assert resp.status_code == 200
+    prefs = resp.json()["preferences"]
+    assert prefs[0]["factor"] == "salary"
 
 def test_phase_flow():
     pref = {
@@ -23,6 +39,11 @@ def test_phase_flow():
         "limit": "Must be at least 3 days remote per week",
         "tradeoff": "Would accept slightly lower salary for full remote",
     }
+    # phase 1
+    resp = client.post("/phase1/preferences", json={"preferences": [pref]})
+    assert resp.status_code == 200
+    prefs = resp.json()["preferences"]
+    assert prefs[0]["factor"] == "Remote work flexibility"
     resp = client.post(
         "/phase2/scenarios", json={"preferences": [pref], "topic": "choosing a new job"}
     )


### PR DESCRIPTION
## Summary
- add `/health` endpoint to `api.py`
- extend API tests to cover `/health`, phase1 and full workflow

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bf64ba48832aa29c96494f83adee